### PR TITLE
chore(*): release version 0.1.1

### DIFF
--- a/.github/workflows/vite-static-workflow.yml
+++ b/.github/workflows/vite-static-workflow.yml
@@ -31,15 +31,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: 'pnpm'
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install
       - name: Build
-        run: npm run build
+        run: pnpm run build
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2024-05-01
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update the `vite-static-workflow` to use pnpm instead of npm
+
 ## [0.1.0] - 2024-05-01
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "run-tsc": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
## [0.1.1] - 2024-05-01

### Fixed

- Update the `vite-static-workflow` to use pnpm instead of npm
