### PR TITLE
fix(ModelCard): prevent images from protruding past top rounded corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Separate type annotations for `Model` and a finite set of `ModelFeature`-s
 - Font family definition called `times` for Times-based serif typefaces
 
+### Fixed
+
+- Protruding model images past the cards' borders
+
 ### Removed
 
 - Catch-all `<App>` component

--- a/src/components/model-card.tsx
+++ b/src/components/model-card.tsx
@@ -13,7 +13,7 @@ function ModelCard({ model }: ModelCardProps): ReactElement {
   return (
     <Card className='flex h-128 w-96 flex-col justify-between gap-2 shadow-md dark:bg-slate-700'>
       <a
-        className='relative h-52 w-full overflow-hidden bg-slate-50 dark:bg-slate-600'
+        className='relative h-52 w-full overflow-hidden rounded-t-md bg-slate-50 dark:bg-slate-600'
         href={model.url || '#'}
         rel="noopener noreferrer"
         target="_blank"


### PR DESCRIPTION
Add a top radius to the anchor tag that wraps the model images in order to make sure that their sharp corners don't stick out beyond the card.