### PR TITLE
fix(index): handle dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New components for `<ModelCard>`, `<ModelFeatures>`, `<Index>`, and `<Root>`
 - Separate type annotations for `Model` and a finite set of `ModelFeature`-s
 - Font family definition called `times` for Times-based serif typefaces
+- Bright border around the model cards in dark mode
+
+### Changed
+
+- Keep the footer background dark when in dark mode
 
 ### Fixed
 
 - Protruding model images past the cards' borders
+- Ensure dark mode toggles with the browser theme
+- Prevent overscrolling to maintain a neat background
 
 ### Removed
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,23 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="overscroll-none">
   <head>
+    <script>
+      const toggleDarkMode = (isDarkMode) => {
+        if (isDarkMode) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      };
+
+      const colorSchemeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      colorSchemeMediaQuery.addEventListener('change', (event) => toggleDarkMode(event.matches));
+
+      const isDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+      toggleDarkMode(isDarkMode);
+    </script>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✨</text></svg>">
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 function Footer(): ReactElement {
   return (
-    <footer className='bg-slate-600 text-center text-slate-300 dark:bg-slate-50 dark:text-slate-800'>
+    <footer className='bg-slate-600 text-center text-slate-300'>
       <span className='whitespace-nowrap'>&copy; {new Date().getFullYear()} <Link to='/'>catwalk.chat</Link></span>
     </footer>
   );

--- a/src/components/model-card.tsx
+++ b/src/components/model-card.tsx
@@ -11,7 +11,7 @@ interface ModelCardProps {
 
 function ModelCard({ model }: ModelCardProps): ReactElement {
   return (
-    <Card className='flex h-128 w-96 flex-col justify-between gap-2 shadow-md dark:bg-slate-700'>
+    <Card className='flex h-128 w-96 flex-col justify-between gap-2 shadow-md dark:bg-slate-700 dark:border-slate-300'>
       <a
         className='relative h-52 w-full overflow-hidden rounded-t-md bg-slate-50 dark:bg-slate-600'
         href={model.url || '#'}

--- a/src/globals.css
+++ b/src/globals.css
@@ -1,60 +1,60 @@
 @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+@tailwind components;
+@tailwind utilities;
 
-  @layer base {
-    :root {
-      --background: 0 0% 100%;
-      --foreground: 222.2 84% 4.9%;
-      --card: 0 0% 100%;
-      --card-foreground: 222.2 84% 4.9%;
-      --popover: 0 0% 100%;
-      --popover-foreground: 222.2 84% 4.9%;
-      --primary: 222.2 47.4% 11.2%;
-      --primary-foreground: 210 40% 98%;
-      --secondary: 210 40% 96.1%;
-      --secondary-foreground: 222.2 47.4% 11.2%;
-      --muted: 210 40% 96.1%;
-      --muted-foreground: 215.4 16.3% 46.9%;
-      --accent: 210 40% 96.1%;
-      --accent-foreground: 222.2 47.4% 11.2%;
-      --destructive: 0 84.2% 60.2%;
-      --destructive-foreground: 210 40% 98%;
-      --border: 214.3 31.8% 91.4%;
-      --input: 214.3 31.8% 91.4%;
-      --ring: 222.2 84% 4.9%;
-      --radius: 0.5rem;
-    }
-
-    .dark {
-      --background: 222.2 84% 4.9%;
-      --foreground: 210 40% 98%;
-      --card: 222.2 84% 4.9%;
-      --card-foreground: 210 40% 98%;
-      --popover: 222.2 84% 4.9%;
-      --popover-foreground: 210 40% 98%;
-      --primary: 210 40% 98%;
-      --primary-foreground: 222.2 47.4% 11.2%;
-      --secondary: 217.2 32.6% 17.5%;
-      --secondary-foreground: 210 40% 98%;
-      --muted: 217.2 32.6% 17.5%;
-      --muted-foreground: 215 20.2% 65.1%;
-      --accent: 217.2 32.6% 17.5%;
-      --accent-foreground: 210 40% 98%;
-      --destructive: 0 62.8% 30.6%;
-      --destructive-foreground: 210 40% 98%;
-      --border: 217.2 32.6% 17.5%;
-      --input: 217.2 32.6% 17.5%;
-      --ring: 212.7 26.8% 83.9%;
-    }
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
   }
 
-  @layer base {
-    * {
-      @apply border-border;
-    }
-
-    body {
-      @apply bg-background text-foreground;
-    }
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
   }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
Ensure dark mode toggles on and off based on the browser theme, both by checking that setting on the initial render and watching it for changes. Based on the guide in https://tailwindcss.com/docs/dark-mode

Show more prominent card borders when in dark mode. Prevent the page from overscrolling to hide inconsistencies with the background color. Keep the footer background dark when in dark mode.